### PR TITLE
Added ignorelist for mods

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
 	name: "Modpack",
 	platforms: [.macOS(.v12)],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.1.4"),
+		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
 	],
 	targets: [

--- a/Sources/Modpack/models.swift
+++ b/Sources/Modpack/models.swift
@@ -10,6 +10,7 @@ struct Config: Codable {
 	let loaders: [String]
 	let versions: [String]
 	let mods: [Mod]
+	let ignore: [Mod]
 }
 
 struct Project: Codable {

--- a/Sources/Modpack/modpack.swift
+++ b/Sources/Modpack/modpack.swift
@@ -3,5 +3,5 @@ import ArgumentParser
 
 @main
 struct Modpack: AsyncParsableCommand {
-	static var configuration = CommandConfiguration(abstract: "A utility for managing modpacks.", version: "2.2.0", subcommands: [Update.self, Report.self])
+	static var configuration = CommandConfiguration(abstract: "A utility for managing modpacks.", version: "2.3.0", subcommands: [Update.self, Report.self])
 }

--- a/Sources/Modpack/report.swift
+++ b/Sources/Modpack/report.swift
@@ -41,7 +41,6 @@ extension Modpack {
 			let project = try await getProject(for: mod.id)
 			
 			if ignoreMods.contains(where: { $0.id == mod.id }) {
-				logger.debug("Ignoring\(dependencyLogModifier) \(project.title)...")
 				return [ModReport(id: mod.id, name: project.title, valid: false, dependency: dependency, ignore: true)]
 			}
 			


### PR DESCRIPTION
This is useful for those wanting to use the Quilt mod loader as currently most Fabric mods can run with the Quilt loader, but specify the Fabric API as a required dependency (when the Quilted Fabric API is needed for the Quilt mod loader). 